### PR TITLE
subheader visuals closer to spec

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -4,6 +4,7 @@
   <meta charset="utf-8" />
   <title>GaiaSubheader Demo</title>
   <meta name="description" content="Demo app for gaia-subheader" />
+  <link rel="stylesheet" type="text/css" href="../bower_components/gaia-fonts/style.css">
 
   <!-- Component -->
   <script>

--- a/script.js
+++ b/script.js
@@ -34,8 +34,30 @@ var proto = Object.create(HTMLElement.prototype);
  * @private
  */
 proto.createdCallback = function() {
+  var tmpl = template.content.cloneNode(true);
+  var shadow = this.createShadowRoot();
+
+  this.inner = tmpl.firstElementChild;
+  shadow.appendChild(tmpl);
   utils.style.call(this, stylesheets);
 };
+
+// HACK: Create a <template> in memory at runtime.
+// When the custom-element is created we clone
+// this template and inject into the shadow-root.
+// Prior to this we would have had to copy/paste
+// the template into the <head> of every app that
+// wanted to use <gaia-switch>, this would make
+// markup changes complicated, and could lead to
+// things getting out of sync. This is a short-term
+// hack until we can import entire custom-elements
+// using HTML Imports (bug 877072).
+var template = document.createElement('template');
+template.innerHTML = '<h2 class="inner">' +
+    '<div class="flex"><div></div></div>' +
+    '<div class="text"><content></content></div>' +
+    '<div class="flex"><div></div></div>' +
+  '</h2>';
 
 // Register and return the constructor
 module.exports = document.registerElement('gaia-subheader', { prototype: proto });

--- a/style.css
+++ b/style.css
@@ -1,11 +1,34 @@
-
 gaia-subheader {
+  font-family: "Fira Sans OT";
+  font-weight: bold;
+  text-transform: uppercase;
   display: block;
   padding: 8px 30px;
-  border-bottom: solid 1px #e6e6e6;
   color: #424242;
-  font-size: 15px;
+  font-size: 14px;
   line-height: 18px;
+}
+
+h2 {
+  display: flex;
+}
+
+h2 .flex {
+  position: relative;
+  flex-grow: 1;
+}
+
+h2 .flex div {
+  position: absolute;
+  width: 100%;
+  border: 1px solid;
+  top: 50%;
+}
+
+h2 .text {
+  flex-shrink: 1;
+  position: relative;
+  padding: 0 10px;
 }
 
 /* -----------------------------------------------------------------


### PR DESCRIPTION
tried to make the subheader look like in the specs. is that approach ok?
before, i tried overlaying a <hr> but that was a stupid approach think.
maybe moz-guys can figure out more specific spacings/colors etc. someone should also update gaia-theme for subheaders
